### PR TITLE
Fix an error that parsing '0.0' results an empty string.

### DIFF
--- a/src/parser/base/grammar.rs
+++ b/src/parser/base/grammar.rs
@@ -61,7 +61,7 @@ impl Parser<'_> {
             self.back(1);
         }
         self.bound()?;
-        Ok(s.trim_end_matches(|c| ".0".contains(c)).to_string())
+        Ok(s.trim_end_matches(".0").to_string())
     }
 
     /// Match float with scientific notation.


### PR DESCRIPTION
Fix a bug that the `float` function returns an empty string if `s` is "0.0".

## Details 

I'm trying to parse a yaml file like below

```
lasers:
- {dist_correction: 0.0, dist_correction_x: 0.0, dist_correction_y: 0.0, focal_distance: 0.0,
  focal_slope: 0.0, horiz_offset_correction: 0.0, laser_id: 0, rot_correction: 0.0,
  vert_correction: -0.2617993877991494, vert_offset_correction: 0.0}
```

and found that float `0.0` corresponds to the empty `NodeFloat("")`.  (I formatted the output for readability).
  
```
[
NodeMap({
    NodeStr("lasers"): NodeSeq(
        [
            NodeMap({
                    NodeStr("dist_correction"): NodeFloat(""), 
                    NodeStr("dist_correction_x"): NodeFloat(""), 
                    NodeStr("dist_correction_y"): NodeFloat(""), 
                    NodeStr("focal_distance"): NodeFloat(""), 
                    NodeStr("focal_slope"): NodeFloat(""), 
                    NodeStr("horiz_offset_correction"): NodeFloat(""), 
                    NodeStr("laser_id"): NodeInt("0"), 
                    NodeStr("rot_correction"): NodeFloat(""), 
                    NodeStr("vert_correction"): NodeFloat("-0.2617993877991494"), 
                    NodeStr("vert_offset_correction"): NodeFloat("")
            })
        ]
    )
})
]
```