### PR TITLE
Deserialization fixes

### DIFF
--- a/src/serde/de.rs
+++ b/src/serde/de.rs
@@ -531,7 +531,7 @@ fn unexpected<R: Repr>(node: &Node<R>, exp: impl Expected) -> SerdeError {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{node, YamlRc};
+    use crate::node;
 
     #[test]
     fn test_deserialize_string_from_various_types() {


### PR DESCRIPTION
Deserialization fails when the parsed type of a field does not line up with the declared type.

For instance if I have a type

```rust
struct Foo {
  bar: String,
  baz: f32,
}
```
And a yaml file
```yaml
bar: 1
baz: 2
```
Deserialization will fail, even though `1` is a valid string and `2` can be readily interpreted as a float.

This PR attempts to fix all of the cases where the yaml type and the declared type may not line up.